### PR TITLE
X11vnc sys tests

### DIFF
--- a/tests/test_x11vnc.py
+++ b/tests/test_x11vnc.py
@@ -1,0 +1,111 @@
+import asyncio
+import platform
+import signal
+import subprocess
+import sys
+import time
+
+import asyncvnc
+import pytest
+
+
+pytest_plugins = ['pytester']
+
+
+# Sending signal.SIGINT on subprocess fails on windows. Use CTRL_* alternatives
+if platform.system() == 'Windows':
+    _KILL_SIGNAL = signal.CTRL_BREAK_EVENT
+    _INT_SIGNAL = signal.CTRL_C_EVENT
+    _PROC_SPAWN_WAIT = 2
+else:
+    _KILL_SIGNAL = signal.SIGKILL
+    _INT_SIGNAL = signal.SIGINT
+    _PROC_SPAWN_WAIT = 0.6 if sys.version_info < (3, 7) else 0.4
+
+
+def sig_prog(proc, sig):
+    '''
+    Kill the process with ``sig``.
+
+    '''
+    proc.send_signal(sig)
+    time.sleep(0.1)
+
+    if not proc.poll():
+        proc.send_signal(_KILL_SIGNAL)
+
+    ret = proc.wait()
+    assert ret
+
+
+# TODO: parametrization with a passwd for
+# https://github.com/barneygale/asyncvnc/issues/1
+@pytest.fixture(
+    params=[None, 'doggy'],
+    ids=lambda param: f'password={param}',
+)
+def x11vnc(
+    request,
+    testdir,
+):
+    '''
+    Run a ``x11vnc`` server as subproc.
+
+    '''
+    port = 5900
+    pw = request.param
+    cmdargs = [
+        'x11vnc',
+        '-display :0',
+        '-noipv6',
+        '-forever',
+        '-noxdamage',
+        '-ncache_cr',
+        f'-rfbport {port}',
+    ]
+
+    if pw:
+        cmdargs.append(f'-passwd {pw}')
+
+    # TODO: x11 doesn't run on windows right so we don't need this?
+    # i guess it depends on whether we want a test for an equivalent
+    # server on windows? no clue what that project would be..
+    spkwargs = {}
+    if platform.system() == 'Windows':
+        # without this, tests can hang on windows forever..
+        spkwargs['creationflags'] = subprocess.CREATE_NEW_PROCESS_GROUP
+
+    proc = testdir.popen(
+        cmdargs,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        **spkwargs,
+    )
+    assert not proc.returncode
+    time.sleep(_PROC_SPAWN_WAIT)
+    yield proc, port, pw
+    sig_prog(proc, _INT_SIGNAL)
+
+
+@pytest.mark.parametrize(
+    'force_vid', [None, 'rgba'],
+    ids=lambda fv: f'force_vid={fv}',
+)
+def test_basic_connection_maybe_auth(
+    x11vnc,
+    force_vid,
+):
+    proc, port, pw = x11vnc
+
+    async def run_client():
+        async with asyncvnc.connect(
+            'localhost',
+            port=port,
+            force_video_mode=force_vid,
+            # TODO: show this is broken
+            password=pw,
+
+        ) as client:
+            print(client)
+
+    asyncio.run(run_client())


### PR DESCRIPTION
As promised a small suite that demonstrates both #1, #2.

Test suite results for me are this on linux:

```python
tests/test_x11vnc.py::test_basic_connection_maybe_auth[password=None-force_vid=None] FAILED                                                             [ 25%]
tests/test_x11vnc.py::test_basic_connection_maybe_auth[password=None-force_vid=rgba] PASSED                                                             [ 50%]
tests/test_x11vnc.py::test_basic_connection_maybe_auth[password=doggy-force_vid=None] FAILED                                                            [ 75%]
tests/test_x11vnc.py::test_basic_connection_maybe_auth[password=doggy-force_vid=rgba] PASSED                                                            [100%]
```

Note that this obviously builds on PR #3

#### Further TODOs
- [ ] we should put this in CI (so i'm guessing GH actions?)
  - haven't looked at how to get `x11vnc` on ac actions instance yet but i'm sure it's been done
- [ ] use the same set of tests against a docker image with minimal settings that are likely the source of the main issue in #2
  - [the `x11vnc-docker` project image](https://github.com/x11vnc/x11vnc-desktop) looks like a good fit